### PR TITLE
14909: Gantt: Add Travis CI and Coveralls badges to the description of the visual on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # powerbi-visuals-gantt
-A Gantt chart is a type of bar chart which illustrates a project timeline or schedule. The Gantt Chart visual shows the Tasks, Start Dates, Durations, % Complete, and Resources for a project. The Gantt Chart visual can be used to show current schedule status using percent-complete shadings and a vertical "TODAY" line. The Legend may be used to group or filter tasks based upon data values.
+[![Build Status](https://travis-ci.org/Microsoft/powerbi-visuals-gantt.svg?branch=master)](https://travis-ci.org/Microsoft/powerbi-visuals-gantt) [![Coverage Status](https://coveralls.io/repos/github/Microsoft/powerbi-visuals-gantt/badge.svg?branch=master)](https://coveralls.io/github/Microsoft/powerbi-visuals-gantt?branch=master)
+
+> A Gantt chart is a type of bar chart which illustrates a project timeline or schedule. The Gantt Chart visual shows the Tasks, Start Dates, Durations, % Complete, and Resources for a project. The Gantt Chart visual can be used to show current schedule status using percent-complete shadings and a vertical "TODAY" line. The Legend may be used to group or filter tasks based upon data values.


### PR DESCRIPTION
* 14909: Gantt: Add Travis CI and Coveralls badges to the description of the visual on GitHub