### PR TITLE
Version 2.0.3 with the ability to display canvas tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.4
+* Added ability to display bandedcolumns as plotbackground
+* Added the option to more precisely configure the X-axis
+* Added the ability to show a certain timeframe (fixed size or relative)
+
 ## 2.0.3
 * Fixed typo: SelectionBuider changed into SelectionBuilder
 * Added ability to display canvas tooltips

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3
+* Fixed typo: SelectionBuider changed into SelectionBuilder
+* Added ability to display canvas tooltips
+
 ## 2.0.2
 * Following #153 https://github.com/microsoft/powerbi-visuals-gantt/issues/153 made the adjustement that resolves the described issue of the horizontal lines overlapping the bars.
 * It now also works while scaling the Task height 

--- a/capabilities.json
+++ b/capabilities.json
@@ -873,6 +873,24 @@
             }
         }
     },
+    "tooltips": {
+        "supportedTypes": {
+            "default": true,
+            "canvas": true
+        },
+        "properties": {
+            "dateFormat": {
+                "displayName": "Date format",
+                "displayNameKey": "Visual_TooltipSettings_DateFormat",
+                "type": {
+                    "text": true
+                }
+            }
+        },
+        "roles": [
+            "tooltips"
+        ]
+    },
     "sorting": {
         "default": {}
     }

--- a/capabilities.json
+++ b/capabilities.json
@@ -551,8 +551,9 @@
                     "suppressFormatPainterCopy": true
                 },
                 "labelColor": {
-                    "displayName": "Color",
+                    "displayName": "Legend Text Color",
                     "displayNameKey": "Visual_Color",
+                    "description": "Legend Text Color",
                     "type": {
                         "fill": {
                             "solid": {
@@ -654,6 +655,13 @@
                         "formatting": {
                             "fontSize": true
                         }
+                    }
+                },
+                "wordWrap": {
+                    "displayName": "Word wrap",
+                    "displayNameKey": "Visual_wordWrap",
+                    "type": {
+                        "bool": true
                     }
                 },
                 "width": {
@@ -785,12 +793,54 @@
                 }
             }
         },
+        "pasettings": {
+            "displayName": "Plot Area",
+            "displayNameKey": "Visual_PlotArea",
+            "properties": {
+                "show": {
+                    "displayName": "Show",
+                    "displayNameKey": "Visual_Show",
+                    "type": {
+                        "bool": true
+                    }
+                },
+                "paColorOdd": {
+                    "displayName": "Color Columns Odd",
+                    "displayNameKey": "Visual_Color",
+                    "type": {
+                        "fill": {
+                            "solid": {
+                                "color": true
+                            }
+                        }
+                    }
+                },
+                "paColorEven": {
+                    "displayName": "Color Columns Even",
+                    "displayNameKey": "Visual_Color",
+                    "type": {
+                        "fill": {
+                            "solid": {
+                                "color": true
+                            }
+                        }
+                    }
+                },
+                "transparency": {
+                    "displayName": "Transparency",
+                    "description": "Transparency of the color columns",
+                    "type": {
+                        "numeric": true
+                    }
+                }
+            }
+        },
         "dateType": {
             "displayName": "Date type",
             "displayNameKey": "Visual_DateType",
             "properties": {
                 "type": {
-                    "displayName": "Type",
+                    "displayName": "Interval",
                     "displayNameKey": "Visual_Type",
                     "type": {
                         "enumeration": [
@@ -847,6 +897,127 @@
                             }
                         }
                     }
+                }
+            }
+        },
+        "xaxis": {
+            "displayName": "X-axis",
+            "displayNameKey": "Visual_Xaxis",
+            "description": "Display X-axis options",
+            "descriptionKey": "Visual_Description_Xaxis",
+            "properties": {
+                "show": {
+                    "displayName": "Show",
+                    "displayNameKey": "Visual_show",
+                    "type": {
+                        "bool": true
+                    }
+                },
+                "axisRangeType": {
+                    "displayName": "Axis range type",
+                    "displayNameKey": "Visual_Xaxis_AxisRangeType",
+                    "description": "Choose the type of scale of the X-axis. Automatically based on first start date and last end date",
+                    "descriptionKey": "Visual_Description_Xaxis_AxisRangeType",
+                    "type": {
+                        "enumeration": [
+                            {
+                                "value": "auto",
+                                "displayName": "auto (default)",
+                                "displayNameKey": "Visual_Xaxis_AxisRangeType_auto"
+                            },
+                            {
+                                "value": "absolute",
+                                "displayName": "absolute",
+                                "displayNameKey": "Visual_Xaxis_AxisRangeType_absolute"
+                            },
+                            {
+                                "value": "relative",
+                                "displayName": "relative",
+                                "displayNameKey": "Visual_Xaxis_AxisRangeType_relative"
+                            }
+                        ]
+                    }
+                },
+                "axisRangeTypeAbsoluteStartDate": {
+                    "displayName": "Abs start date",
+                    "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_absolute_StartDate",
+                    "type": {
+                        "text": true
+                    },
+                    "description": "Enter the absolute start day (absolute must be selected)",
+                    "descriptionKey": "Visual_Description_Xaxis_AxisRangeTypeAbsoluteStartDate"
+                },
+                "axisRangeTypeAbsoluteEndDate": {
+                    "displayName": "Abs end date",
+                    "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_absolute_EndDate",
+                    "type": {
+                        "text": true
+                    },
+                    "description": "Enter the absolute end day (absolute must be selected)",
+                    "descriptionKey": "Visual_Description_Xaxis_AxisRangeTypeAbsoluteEndDate"
+                },
+                "axisRangeTypeRelativeReferenceDateMethod": {
+                    "displayName": "Method to determine the reference date used with the relative option",
+                    "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_ReferenceDate",
+                    "type": {
+                        "enumeration": [
+                            {
+                                "value": "MonthStart",
+                                "displayName": "Current month start",
+                                "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_ReferenceDate_MonthStart"
+                            },
+                            {
+                                "value": "MonthMiddle",
+                                "displayName": "Current month middle",
+                                "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_ReferenceDate_MonthMiddle"
+                            },
+                            {
+                                "value": "MonthEnd",
+                                "displayName": "Current month end",
+                                "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_ReferenceDate_MonthEnd"
+                            },
+                            {
+                                "value": "QuarterStart",
+                                "displayName": "Current quarter start",
+                                "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_ReferenceDate_QuarterStart"
+                            },
+                            {
+                                "value": "QuarterMiddle",
+                                "displayName": "Current quarter middle",
+                                "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_ReferenceDate_QuarterMiddle"
+                            },
+                            {
+                                "value": "QuarterEnd",
+                                "displayName": "Current quarter end",
+                                "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_ReferenceDate_QuarterEnd"
+                            },
+                            {
+                                "value": "Current date",
+                                "displayName": "Current date",
+                                "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_ReferenceDate_Current"
+                            }
+                        ]
+                    },
+                    "description": "Enter the reference start day (relative must be selected)",
+                    "descriptionKey": "Visual_Description_Xaxis_AxisRangeTypeRelativeReferenceDate"
+                },
+                "axisRangeTypeRelativeStartInt": {
+                    "displayName": "Units relative start date",
+                    "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_StartInt",
+                    "type": {
+                        "numeric": true
+                    },
+                    "description": "Enter the amount of intervals (specified in Date type) for the start of the X-axis (relative must be selected)",
+                    "descriptionKey": "Visual_Description_Xaxis_AxisRangeTypeRelativeStartInt"
+                },
+                "axisRangeTypeRelativeEndInt": {
+                    "displayName": "Units relative end date",
+                    "displayNameKey": "Visual_Description_Xaxis_AxisRangeType_relative_StartInt",
+                    "type": {
+                        "numeric": true
+                    },
+                    "description": "Enter the amount of intervals (specified in Date type) for the end of the X-axis (relative must be selected)",
+                    "descriptionKey": "Visual_Description_Xaxis_AxisRangeTypeRelativeStartInt"
                 },
                 "axisColor": {
                     "displayName": "Axis Color",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8633,9 +8633,9 @@
       "dev": true
     },
     "powerbi-visuals-api": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/powerbi-visuals-api/-/powerbi-visuals-api-2.6.0.tgz",
-      "integrity": "sha512-HQcMaMPXzV85cfH7Ed3FERCakEhgs+pm3z9/Dno7iZahtoX9DeLF0jtuyBWz8cjOm8etKkp54L2dPYkj71eZ2A==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/powerbi-visuals-api/-/powerbi-visuals-api-2.6.1.tgz",
+      "integrity": "sha512-UNp9X5OKTfyLP9eZ2e9K4YvwoaFA+aaUgCi1j6LBVmXGFDVcJGnTYeK5JhAvQsXingVnpQf8Z/aIfLiQ9FtnBw==",
       "dev": true,
       "requires": {
         "semver": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-gantt",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A Gantt chart is a type of bar chart which illustrates a project timeline or schedule. The Gantt Chart visual shows the Tasks, Start Dates, Durations, % Complete, and Resources for a project. The Gantt Chart visual can be used to show current schedule status using percent-complete shadings and a vertical \"TODAY\" line. The Legend may be used to group or filter tasks based upon data values.",
   "repository": {
     "type": "git",
@@ -29,18 +29,18 @@
   "homepage": "https://github.com/Microsoft/powerbi-visuals-gantt#readme",
   "dependencies": {
     "core-js": "^3.1.4",
-    "d3": "5.7.0",
+    "d3": "^5.7.0",
     "del-cli": "1.1.0",
     "jquery": "3.4.1",
     "lodash": "4.17.11",
     "powerbi-visuals-utils-chartutils": "2.4.0",
     "powerbi-visuals-utils-colorutils": "2.2.0",
     "powerbi-visuals-utils-dataviewutils": "2.2.0",
-    "powerbi-visuals-utils-formattingutils": "4.3.0",
+    "powerbi-visuals-utils-formattingutils": "^4.3.0",
     "powerbi-visuals-utils-interactivityutils": "5.5.0",
-    "powerbi-visuals-utils-svgutils": "2.2.0",
+    "powerbi-visuals-utils-svgutils": "^2.2.0",
     "powerbi-visuals-utils-tooltiputils": "2.2.0",
-    "powerbi-visuals-utils-typeutils": "2.2.0"
+    "powerbi-visuals-utils-typeutils": "^2.2.0"
   },
   "devDependencies": {
     "@types/d3": "5.7.2",
@@ -68,8 +68,8 @@
     "karma-typescript-preprocessor": "0.4.0",
     "karma-webpack": "3.0.5",
     "less": "3.9.0",
-    "powerbi-models": "1.2.0",
-    "powerbi-visuals-api": "^2.6.0",
+    "powerbi-models": "^1.2.0",
+    "powerbi-visuals-api": "^2.6.1",
     "powerbi-visuals-tools": "^3.1.2",
     "powerbi-visuals-utils-testutils": "2.2.0",
     "puppeteer": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-gantt",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A Gantt chart is a type of bar chart which illustrates a project timeline or schedule. The Gantt Chart visual shows the Tasks, Start Dates, Durations, % Complete, and Resources for a project. The Gantt Chart visual can be used to show current schedule status using percent-complete shadings and a vertical \"TODAY\" line. The Legend may be used to group or filter tasks based upon data values.",
   "repository": {
     "type": "git",

--- a/pbiviz.json
+++ b/pbiviz.json
@@ -1,10 +1,10 @@
 {
   "visual": {
     "name": "Gantt",
-    "displayName": "Gantt 2.0.3",
+    "displayName": "Gantt 2.0.4",
     "guid": "Gantt1448688115699",
     "visualClassName": "Gantt",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "description": "A Gantt chart is a type of bar chart which illustrates a project timeline or schedule. The Gantt Chart visual shows the Tasks, Start Dates, Durations, % Complete, and Resources for a project. The Gantt Chart visual can be used to show current schedule status using percent-complete shadings and a vertical \"TODAY\" line. The Legend may be used to group or filter tasks based upon data values.",
     "supportUrl": "https://community.powerbi.com",
     "gitHubUrl": "https://github.com/Microsoft/powerbi-visuals-gantt"

--- a/pbiviz.json
+++ b/pbiviz.json
@@ -1,10 +1,10 @@
 {
   "visual": {
     "name": "Gantt",
-    "displayName": "Gantt 2.0.2",
+    "displayName": "Gantt 2.0.3",
     "guid": "Gantt1448688115699",
     "visualClassName": "Gantt",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "A Gantt chart is a type of bar chart which illustrates a project timeline or schedule. The Gantt Chart visual shows the Tasks, Start Dates, Durations, % Complete, and Resources for a project. The Gantt Chart visual can be used to show current schedule status using percent-complete shadings and a vertical \"TODAY\" line. The Legend may be used to group or filter tasks based upon data values.",
     "supportUrl": "https://community.powerbi.com",
     "gitHubUrl": "https://github.com/Microsoft/powerbi-visuals-gantt"

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -112,6 +112,7 @@ import IAxisProperties = axisInterfaces.IAxisProperties;
 import { Behavior, BehaviorOptions } from "./behavior";
 import {
     Task,
+    TooltipReportPageEnabledDataPoint,
     Line,
     LinearStop,
     MilestonePath,
@@ -791,13 +792,13 @@ export class Gantt implements IVisual {
             milestonesCategory.values.forEach((value: PrimitiveValue, index: number) => milestones.push({ value, index }));
             milestones.forEach((milestone) => {
                 const milestoneObjects = milestonesCategory.objects && milestonesCategory.objects[milestone.index];
-                const selectionBuider: ISelectionIdBuilder = host
+                const selectionBuilder: ISelectionIdBuilder = host
                     .createSelectionIdBuilder()
                     .withCategory(milestonesCategory, milestone.index);
 
                 const milestoneDataPoint: MilestoneDataPoint = {
                     name: milestone.value as string,
-                    identity: selectionBuider.createSelectionId(),
+                    identity: selectionBuilder.createSelectionId(),
                     shapeType: milestoneObjects && milestoneObjects.milestones && milestoneObjects.milestones.shapeType ?
                         milestoneObjects.milestones.shapeType as string : MilestoneShapeTypes.Rhombus,
                     color: milestoneObjects && milestoneObjects.milestones && milestoneObjects.milestones.fill ?
@@ -859,7 +860,7 @@ export class Gantt implements IVisual {
             let tooltips: VisualTooltipDataItem[] = [];
             let stepDurationTransformation: number = 0;
 
-            const selectionBuider: ISelectionIdBuilder = host
+            const selectionBuilder: ISelectionIdBuilder = host
                 .createSelectionIdBuilder()
                 .withCategory(dataView.categorical.categories[0], index);
 
@@ -870,7 +871,7 @@ export class Gantt implements IVisual {
                             (typeMeta: TaskTypeMetadata) => typeMeta.name === group.Duration.source.groupName);
 
                         if (taskType) {
-                            selectionBuider.withCategory(taskType.selectionColumn, 0);
+                            selectionBuilder.withCategory(taskType.selectionColumn, 0);
                             color = colorHelper.getColorForMeasure(taskType.columnGroup.objects, taskType.name);
                         }
 
@@ -904,7 +905,7 @@ export class Gantt implements IVisual {
                             (typeMeta: TaskTypeMetadata) => typeMeta.name === group.EndDate.source.groupName);
 
                         if (taskType) {
-                            selectionBuider.withCategory(taskType.selectionColumn, 0);
+                            selectionBuilder.withCategory(taskType.selectionColumn, 0);
                             color = colorHelper.getColorForMeasure(taskType.columnGroup.objects, taskType.name);
                         }
 
@@ -930,7 +931,7 @@ export class Gantt implements IVisual {
                 });
             }
 
-            const selectionId: powerbi.extensibility.ISelectionId = selectionBuider.createSelectionId();
+            const selectionId: powerbi.extensibility.ISelectionId = selectionBuilder.createSelectionId();
             const extraInformation: ExtraInformation[] = [];
             const resource: string = (values.Resource && values.Resource[index] as string) || "";
             const parent: string = (values.Parent && values.Parent[index] as string) || null;
@@ -1001,7 +1002,7 @@ export class Gantt implements IVisual {
                         daysOffList: null,
                         wasDowngradeDurationUnit: null,
                         selected: null,
-                        identity: selectionBuider.createSelectionId(),
+                        identity: selectionBuilder.createSelectionId(),
                         Milestones: Milestone && startDate ? [{ type: Milestone, start: startDate, tooltipInfo: null, category: categoryValue as string }] : []
                     };
 
@@ -2088,7 +2089,7 @@ export class Gantt implements IVisual {
         this.taskDaysOffRender(taskSelection, taskConfigHeight);
         this.taskResourceRender(taskSelection, taskConfigHeight);
 
-        this.renderTooltip(taskSelection);
+        this.renderTooltipReportPage(taskSelection);
     }
 
 
@@ -2345,7 +2346,7 @@ export class Gantt implements IVisual {
             .attr("transform", (data: MilestonePath) => transformForMilestone(data.taskID, data.start))
             .attr("fill", (data: MilestonePath) => this.getMilestoneColor(data.type));
 
-        this.renderTooltip(taskMilestonesSelectionMerged);
+        this.renderTooltipReportPage(taskMilestonesSelectionMerged);
     }
 
     /**
@@ -2821,7 +2822,7 @@ export class Gantt implements IVisual {
             .attr("y2", (line: Line) => line.y2)
             .style("stroke", (line: Line) => line.x1 === this.timeScale(timestamp) ? todayColor : "#ccc");
 
-        this.renderTooltip(chartLineSelectionMerged);
+        this.renderTooltipReportPage(chartLineSelectionMerged);
 
         chartLineSelection
             .exit()
@@ -2848,6 +2849,13 @@ export class Gantt implements IVisual {
             (tooltipEvent: TooltipEventArgs<TooltipEnabledDataPoint>) => {
                 return tooltipEvent.data.tooltipInfo;
             });
+    }
+
+    private renderTooltipReportPage(selection: Selection<Line | Task | MilestonePath>): void {
+        this.tooltipServiceWrapper.addTooltip(selection,
+            (tooltipEvent: TooltipEventArgs<TooltipReportPageEnabledDataPoint>) => { return tooltipEvent.data.tooltipInfo },
+            (tooltipEvent: TooltipEventArgs<TooltipReportPageEnabledDataPoint>) => { return tooltipEvent.data.identity }
+        )
     }
 
     private updateElementsPositions(margin: IMargin): void {

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -2853,8 +2853,8 @@ export class Gantt implements IVisual {
 
     private renderTooltipReportPage(selection: Selection<Line | Task | MilestonePath>): void {
         this.tooltipServiceWrapper.addTooltip(selection,
-            (tooltipEvent: TooltipEventArgs<TooltipReportPageEnabledDataPoint>) => { return tooltipEvent.data.tooltipInfo },
-            (tooltipEvent: TooltipEventArgs<TooltipReportPageEnabledDataPoint>) => { return tooltipEvent.data.identity }
+            (tooltipEvent: TooltipEventArgs<TooltipReportPageEnabledDataPoint>) => { return tooltipEvent.data.tooltipInfo ;},
+            (tooltipEvent: TooltipEventArgs<TooltipReportPageEnabledDataPoint>) => { return tooltipEvent.data.identity ;}
         );
     }
 

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -2855,7 +2855,7 @@ export class Gantt implements IVisual {
         this.tooltipServiceWrapper.addTooltip(selection,
             (tooltipEvent: TooltipEventArgs<TooltipReportPageEnabledDataPoint>) => { return tooltipEvent.data.tooltipInfo },
             (tooltipEvent: TooltipEventArgs<TooltipReportPageEnabledDataPoint>) => { return tooltipEvent.data.identity }
-        )
+        );
     }
 
     private updateElementsPositions(margin: IMargin): void {

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -2853,8 +2853,8 @@ export class Gantt implements IVisual {
 
     private renderTooltipReportPage(selection: Selection<Line | Task | MilestonePath>): void {
         this.tooltipServiceWrapper.addTooltip(selection,
-            (tooltipEvent: TooltipEventArgs<TooltipReportPageEnabledDataPoint>) => { return tooltipEvent.data.tooltipInfo ;},
-            (tooltipEvent: TooltipEventArgs<TooltipReportPageEnabledDataPoint>) => { return tooltipEvent.data.identity ;}
+            (tooltipEvent: TooltipEventArgs<TooltipReportPageEnabledDataPoint>) => { return tooltipEvent.data.tooltipInfo; },
+            (tooltipEvent: TooltipEventArgs<TooltipReportPageEnabledDataPoint>) => { return tooltipEvent.data.identity; }
         );
     }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -32,6 +32,7 @@ import DataViewCategoryColumn = powerbi.DataViewCategoryColumn;
 import DataViewValueColumnGroup = powerbi.DataViewValueColumnGroup;
 import ISelectionId = powerbi.visuals.ISelectionId;
 import VisualTooltipDataItem = powerbi.extensibility.VisualTooltipDataItem;
+import { TooltipEnabledDataPoint } from "powerbi-visuals-utils-tooltiputils";
 
 import { interactivitySelectionService as interactivityService } from "powerbi-visuals-utils-interactivityutils";
 import SelectableDataPoint = interactivityService.SelectableDataPoint;
@@ -85,6 +86,10 @@ export interface Task extends SelectableDataPoint {
     stepDurationTransformation?: number;
     highlight?: boolean;
     Milestones?: Milestone[];
+}
+
+export interface TooltipReportPageEnabledDataPoint extends TooltipEnabledDataPoint {
+    identity?: ISelectionId;
 }
 
 export interface GroupedTask {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -38,7 +38,9 @@ export class GanttSettings extends DataViewObjectsParser {
     taskConfig: TaskConfigSettings = new TaskConfigSettings();
     taskCompletion: TaskCompletionSettings = new TaskCompletionSettings();
     taskResource: TaskResourceSettings = new TaskResourceSettings();
+    pasettings: PlotAreaSettings = new PlotAreaSettings();
     dateType: DateTypeSettings = new DateTypeSettings();
+    xaxis: customXaxisSettings = new customXaxisSettings();
     tooltipConfig: TooltipConfigSettings = new TooltipConfigSettings();
     milestones: MilestonesSettings = new MilestonesSettings();
 }
@@ -77,6 +79,7 @@ export class TaskLabelsSettings {
     show: boolean = true;
     fill: string = "#000000";
     fontSize: number = 9;
+    wordWrap: boolean = true;
     width: number = 110;
 }
 
@@ -102,8 +105,26 @@ export class DateTypeSettings {
     // tslint:disable-next-line:no-reserved-keywords
     type: DateTypes = DateTypes.Week;
     todayColor: string = "#000000";
+}
+
+export class customXaxisSettings {
+    show: boolean = true;
+    axisRangeType: string = "auto";
+    axisRangeTypeAbsoluteStartDate: string = "1 Jan 2018";
+    axisRangeTypeAbsoluteEndDate: string = "31 Dec 2020";
+    axisRangeTypeRelativeReferenceDateMethod: string = "Current date";
+    axisRangeTypeRelativeStartInt: number = -1;
+    axisRangeTypeRelativeEndInt: number = 3;
+    axisShow: boolean = true;
     axisColor: string = "#000000";
     axisTextColor: string = "#000000";
+}
+export class PlotAreaSettings {
+    show: boolean = true;
+    paShowBandedColumns: boolean = false;
+    paColorOdd: string = "#ff0000";
+    paColorEven: string = "#00ff00";
+    transparency: number = 20;
 }
 
 export class TooltipConfigSettings {


### PR DESCRIPTION
Adjusted the code, so it displays canvas tooltips.
This time by creating an interface named TooltipReportPageEnabledDataPoint (which is created by extending the interface TooltipEnabledDataPoint in the file interfaces.ts) 

Also... removed a typo in SelectionBuider.

Hopefully this adjustment will pass the automatic tests.