### PR TITLE
Fix disappearing bars bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.5
+* Fix issue with disappearing of the task bar
+* Fix issue with shifted task bar when `barsRoundedCorners` is enabled
+
 ## 3.0.4
 * Fix issue when milestones were rendered twice
 * Show customized legend name in the tooltips

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerbi-visuals-gantt",
-  "version": "3.0.4.0",
+  "version": "3.0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerbi-visuals-gantt",
-      "version": "3.0.4.0",
+      "version": "3.0.5.0",
       "license": "MIT",
       "dependencies": {
         "d3-collection": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-gantt",
-  "version": "3.0.4.0",
+  "version": "3.0.5.0",
   "description": "A Gantt chart is a type of bar chart which illustrates a project timeline or schedule. The Gantt Chart visual shows the Tasks, Start Dates, Durations, % Complete, and Resources for a project. The Gantt Chart visual can be used to show current schedule status using percent-complete shadings and a vertical \"TODAY\" line. The Legend may be used to group or filter tasks based upon data values.",
   "repository": {
     "type": "git",

--- a/pbiviz.json
+++ b/pbiviz.json
@@ -1,10 +1,10 @@
 {
   "visual": {
     "name": "Gantt",
-    "displayName": "Gantt 3.0.4.0",
+    "displayName": "Gantt 3.0.5.0",
     "guid": "Gantt1448688115699",
     "visualClassName": "Gantt",
-    "version": "3.0.4.0",
+    "version": "3.0.5.0",
     "description": "A Gantt chart is a type of bar chart which illustrates a project timeline or schedule. The Gantt Chart visual shows the Tasks, Start Dates, Durations, % Complete, and Resources for a project. The Gantt Chart visual can be used to show current schedule status using percent-complete shadings and a vertical \"TODAY\" line. The Legend may be used to group or filter tasks based upon data values.",
     "supportUrl": "https://community.powerbi.com",
     "gitHubUrl": "https://github.com/Microsoft/powerbi-visuals-gantt"

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -52,6 +52,7 @@ export function getFillOpacity(
 }
 
 export interface BehaviorOptions extends IBehaviorOptions<Task> {
+    rootElement: Selection<any>;
     clearCatcher: Selection<any>;
     taskSelection: Selection<Task>;
     legendSelection: Selection<any>;
@@ -138,6 +139,19 @@ export class Behavior implements IInteractiveBehavior {
     }
 
     private bindContextMenu(): void {
+        this.options.rootElement.on("contextmenu", (event: MouseEvent) => {
+            if (!event) {
+                return;
+            }
+
+            this.selectionHandler.handleContextMenu(null, {
+                x: event.clientX,
+                y: event.clientY,
+            })
+
+            event.preventDefault();
+        });
+
         this.options.taskSelection.on("contextmenu", (event: MouseEvent, task: Task) => {
             if (event) {
                 this.selectionHandler.handleContextMenu(

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -52,7 +52,6 @@ export function getFillOpacity(
 }
 
 export interface BehaviorOptions extends IBehaviorOptions<Task> {
-    rootElement: Selection<any>;
     clearCatcher: Selection<any>;
     taskSelection: Selection<Task>;
     legendSelection: Selection<any>;
@@ -139,19 +138,6 @@ export class Behavior implements IInteractiveBehavior {
     }
 
     private bindContextMenu(): void {
-        this.options.rootElement.on("contextmenu", (event: MouseEvent) => {
-            if (!event) {
-                return;
-            }
-
-            this.selectionHandler.handleContextMenu(null, {
-                x: event.clientX,
-                y: event.clientY,
-            })
-
-            event.preventDefault();
-        });
-
         this.options.taskSelection.on("contextmenu", (event: MouseEvent, task: Task) => {
             if (event) {
                 this.selectionHandler.handleContextMenu(

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -2397,11 +2397,6 @@ export class Gantt implements IVisual {
      * @param barsRoundedCorners are bars with rounded corners
      */
     private drawTaskRect(task: Task, taskConfigHeight: number, barsRoundedCorners: boolean): string {
-        // milestones are already rendered in the function MilestonesRender
-        if (task.Milestones && task.Milestones.length > 0) {
-            return undefined;
-        }
-
         const x = this.hasNotNullableDates ? Gantt.TimeScale(task.start) : 0,
             y = Gantt.getBarYCoordinate(task.index, taskConfigHeight) + (task.index + 1) * this.getResourceLabelTopMargin(),
             width = this.getTaskRectWidth(task),
@@ -2409,7 +2404,7 @@ export class Gantt implements IVisual {
             radius = Gantt.RectRound;
 
         if (barsRoundedCorners) {
-            return drawRoundedRectByPath(x, y, width + Gantt.RectRound, height, radius);
+            return drawRoundedRectByPath(x, y, width, height, radius);
         }
 
         return drawNotRoundedRectByPath(x, y, width, height);

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -1726,6 +1726,7 @@ export class Gantt implements IVisual {
     private bindInteractivityService(tasks: Task[]): void {
         if (this.interactivityService) {
             const behaviorOptions: BehaviorOptions = {
+                rootElement: this.body,
                 clearCatcher: this.clearCatcher,
                 taskSelection: this.taskGroup.selectAll(Gantt.SingleTask.selectorName),
                 legendSelection: this.body.selectAll(Gantt.LegendItems.selectorName),

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -1726,8 +1726,7 @@ export class Gantt implements IVisual {
     private bindInteractivityService(tasks: Task[]): void {
         if (this.interactivityService) {
             const behaviorOptions: BehaviorOptions = {
-                rootElement: this.body,
-                clearCatcher: this.clearCatcher,
+                clearCatcher: this.body,
                 taskSelection: this.taskGroup.selectAll(Gantt.SingleTask.selectorName),
                 legendSelection: this.body.selectAll(Gantt.LegendItems.selectorName),
                 subTasksCollapse: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ export const drawRoundedRectByPath = (x: number, y: number, width: number, heigh
 
     return `
     M${x},${y}
-    h${width - 2 * r}
+    h${width - r}
     a${r},${r} 0 0 1 ${r},${r}
     v${height - 2 * r}
     a${r},${r} 0 0 1 ${-r},${r}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import lodashRange from "lodash.range";
 
 export const drawRoundedRectByPath = (x: number, y: number, width: number, height: number, radius: number) => {
     if (!width || !height) {
-        return;
+        return undefined;
     }
     const r = radius;
 
@@ -23,7 +23,7 @@ export const drawRoundedRectByPath = (x: number, y: number, width: number, heigh
 
 export const drawNotRoundedRectByPath = (x: number, y: number, width: number, height: number) => {
     if (!width || !height) {
-        return;
+        return undefined;
     }
     return `
     M${x},${y}

--- a/test/visualTest.ts
+++ b/test/visualTest.ts
@@ -1666,7 +1666,7 @@ describe("Gantt", () => {
                         const text: string | null = e.textContent;
                         const taskResourcesX = +(e.getAttribute("x") ?? 0);
                         const taskResourcesY = +(e.getAttribute("y") ?? 0);
-                        const taskRectX = taskRects[i].getBBox().x + VisualClass.RectRound * 2;
+                        const taskRectX = taskRects[i].getBBox().x + VisualClass.RectRound;
                         const taskRectY = taskRects[i].getBBox().y;
 
                         if (text) {


### PR DESCRIPTION
Previous commits made some task bars disappear, because milestones were rendered instead of them. It is unexpected behaviour and following commits designed to fix the issue.

Also, there is another issue with task bars being shifted when "rounded corners" setting is enabled. Commit 236e5a5 is addressing the bug.