### PR TITLE
Set category labels background to enabled by default for consistency with previous versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1
+* Set category labels background to enabled by default for consistency with previous versions
+* Fix npm vulnerabilities
+
 ## 3.1.0
 ### Visual changes
 * Add new card settings for background colors

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerbi-visuals-gantt",
-  "version": "3.1.0.0",
+  "version": "3.1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerbi-visuals-gantt",
-      "version": "3.1.0.0",
+      "version": "3.1.1.0",
       "license": "MIT",
       "dependencies": {
         "d3-collection": "^1.0.7",
@@ -74,12 +74,12 @@
         "karma-webpack": "^5.0.1",
         "less": "^4.2.0",
         "less-loader": "^12.2.0",
-        "playwright-chromium": "^1.47.2",
+        "playwright-chromium": "^1.51.0",
         "powerbi-visuals-tools": "^5.5.1",
         "powerbi-visuals-utils-testutils": "^6.1.1",
         "style-loader": "^4.0.0",
         "ts-loader": "^9.5.1",
-        "typescript": "^5.6.2",
+        "typescript": "^5.7.2",
         "webpack": "^5.95.0"
       }
     },
@@ -270,14 +270,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.26.10"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -344,9 +344,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7111,14 +7111,14 @@
       }
     },
     "node_modules/playwright-chromium": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/playwright-chromium/-/playwright-chromium-1.50.1.tgz",
-      "integrity": "sha512-0IKyCdwS5dDoGE3EqqfYtX24qF6+ef1UI6OLn2VUi2aHOgsI/KnESRm6/Ws0W78SrwhLi6lLlAL6fQISoO1cfw==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/playwright-chromium/-/playwright-chromium-1.51.0.tgz",
+      "integrity": "sha512-vvTfgpnpy/OHzszS6jtRxvltC0J3x2Eko925FciIC0IN3KC1fg76veqV9AVWIasR+JTq9ZQh9V5Yqz8DPl38Lg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.50.1"
+        "playwright-core": "1.51.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -7128,9 +7128,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
-      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.0.tgz",
+      "integrity": "sha512-x47yPE3Zwhlil7wlNU/iktF7t2r/URR3VLbH6EknJd/04Qc/PSJ0EY3CMXipmglLG+zyRxW6HNo2EGbKLHPWMg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-gantt",
-  "version": "3.1.0.0",
+  "version": "3.1.1.0",
   "description": "A Gantt chart is a type of bar chart which illustrates a project timeline or schedule. The Gantt Chart visual shows the Tasks, Start Dates, Durations, % Complete, and Resources for a project. The Gantt Chart visual can be used to show current schedule status using percent-complete shadings and a vertical \"TODAY\" line. The Legend may be used to group or filter tasks based upon data values.",
   "repository": {
     "type": "git",
@@ -92,12 +92,12 @@
     "karma-webpack": "^5.0.1",
     "less": "^4.2.0",
     "less-loader": "^12.2.0",
-    "playwright-chromium": "^1.47.2",
+    "playwright-chromium": "^1.51.0",
     "powerbi-visuals-tools": "^5.5.1",
     "powerbi-visuals-utils-testutils": "^6.1.1",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.5.1",
-    "typescript": "^5.6.2",
+    "typescript": "^5.7.2",
     "webpack": "^5.95.0"
   }
 }

--- a/pbiviz.json
+++ b/pbiviz.json
@@ -1,7 +1,7 @@
 {
   "visual": {
     "name": "Gantt",
-    "displayName": "Gantt 3.1.0.0",
+    "displayName": "Gantt 3.1.1.0",
     "guid": "Gantt1448688115699",
     "visualClassName": "Gantt",
     "version": "3.1.0.0",

--- a/src/ganttChartSettingsModels.ts
+++ b/src/ganttChartSettingsModels.ts
@@ -638,7 +638,7 @@ export class BackgroundCardSettings extends CompositeCard {
         name: "categoryLabelsBackgroundEnable",
         displayName: "Enable background",
         displayNameKey: "Visual_Enable_Background",
-        value: false,
+        value: true,
     });
 
     categoryLabelsBackgroundColor = new formattingSettings.ColorPicker({


### PR DESCRIPTION
By default category labels background is disabled. This makes the category labels column look transparent, which is different from previous versions.
<img width="295" alt="image" src="https://github.com/user-attachments/assets/5a998143-c8a4-4d84-86ba-8e94465c6e7b" />
