### PR TITLE
feat(): toggle to show milestones vertical line

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -469,6 +469,11 @@
                     "type": {
                         "text": true
                     }
+                },
+                "showVerticalLines": {
+                    "type": {
+                        "bool": true
+                    }
                 }
             }
         },

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -1714,7 +1714,7 @@ export class Gantt implements IVisual {
         this.renderTasks(groupedTasks);
         this.updateTaskLabels(groupedTasks, settings.taskLabelsCardSettings.width.value);
         this.updateElementsPositions(this.margin);
-        this.createMilestoneLine(groupedTasks);
+        this.createMilestoneLine(groupedTasks, settings.milestonesCardSettings.showVerticalLines.value);
 
         if (this.formattingSettings.generalCardSettings.scrollToCurrentTime.value && this.hasNotNullableDates) {
             this.scrollToMilestoneLine(axisLength);
@@ -3014,6 +3014,7 @@ export class Gantt implements IVisual {
     */
     private createMilestoneLine(
         tasks: GroupedTask[],
+        showVerticalLine: boolean,
         timestamp: number = Date.now(),
         milestoneTitle?: string): void {
         if (!this.hasNotNullableDates) {
@@ -3054,28 +3055,34 @@ export class Gantt implements IVisual {
             .selectAll(Gantt.ChartLine.selectorName)
             .data(line);
 
-        const chartLineSelectionMerged = chartLineSelection
-            .enter()
-            .append("line")
-            .merge(chartLineSelection);
+        if (showVerticalLine) {
+            const chartLineSelectionMerged = chartLineSelection
+                .enter()
+                .append("line")
+                .merge(chartLineSelection);
 
-        chartLineSelectionMerged.classed(Gantt.ChartLine.className, true);
+            chartLineSelectionMerged.classed(Gantt.ChartLine.className, true);
 
-        chartLineSelectionMerged
-            .attr("x1", (line: Line) => line.x1)
-            .attr("y1", (line: Line) => line.y1)
-            .attr("x2", (line: Line) => line.x2)
-            .attr("y2", (line: Line) => line.y2)
-            .style("stroke", (line: Line) => {
-                const color: string = line.x1 === Gantt.TimeScale(timestamp) ? todayColor : Gantt.DefaultValues.MilestoneLineColor;
-                return this.colorHelper.getHighContrastColor("foreground", color);
-            });
+            chartLineSelectionMerged
+                .attr("x1", (line: Line) => line.x1)
+                .attr("y1", (line: Line) => line.y1)
+                .attr("x2", (line: Line) => line.x2)
+                .attr("y2", (line: Line) => line.y2)
+                .style("stroke", (line: Line) => {
+                    const color: string = line.x1 === Gantt.TimeScale(timestamp) ? todayColor : Gantt.DefaultValues.MilestoneLineColor;
+                    return this.colorHelper.getHighContrastColor("foreground", color);
+                });
 
-        this.renderTooltip(chartLineSelectionMerged);
+            this.renderTooltip(chartLineSelectionMerged);
+            chartLineSelection
+                .exit()
+                .remove();
+        } else {
+            this.renderTooltip(chartLineSelection);
+            chartLineSelection
+                .remove();
+        }
 
-        chartLineSelection
-            .exit()
-            .remove();
     }
 
     private scrollToMilestoneLine(axisLength: number,

--- a/src/ganttChartSettingsModels.ts
+++ b/src/ganttChartSettingsModels.ts
@@ -297,9 +297,15 @@ export class MilestonesCardSettings extends Card {
         value: shapesOptions[0]
     });
 
+    showVerticalLines = new formattingSettings.ToggleSwitch({
+        name: "showVerticalLines",
+        displayName: "Show vertical lines",
+        value: true
+    })
+
     name: string = "milestones";
     displayNameKey: string = "Visual_Milestones";
-    slices = [];
+    slices = [this.showVerticalLines];
 }
 
 export class TaskLabelsCardSettings extends Card {
@@ -543,7 +549,7 @@ export class GanttChartSettingsModel extends Model {
             }
         }
 
-        this.milestonesCardSettings.slices = newSlices;
+        this.milestonesCardSettings.slices = [this.milestonesCardSettings.showVerticalLines, ...newSlices];
     }
 
     public populateLegend(dataPoints: LegendDataPoint[], localizationManager: ILocalizationManager) {


### PR DESCRIPTION
Adds a toggle to the Milestones property that allows you to hide the vertical line of milestones

![image](https://github.com/user-attachments/assets/82fb069e-f15c-42ab-9f85-fd353683e636)

![image](https://github.com/user-attachments/assets/b1904ccd-fc43-4e55-9b4c-95d12479b110)

If you need any adjustments due to standardization, let me know.

#250 