### PR TITLE
refactor: enable useUnknownInCatchVariables, alwaysStrict and noImplicitThis; type catch vars as unknown and annotate d3 'this' callbacks

### DIFF
--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -1922,7 +1922,7 @@ export class Gantt implements IVisual {
             this.updateInternal(options);
         } catch (error: unknown) {
             const errorMessage = error instanceof Error ? error.message : String(error);
-            console.error(errorMessage);
+            console.error("Gantt rendering failed", errorMessage, error);
             this.eventService.renderingFailed(options, errorMessage);
         }
     }

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -1920,9 +1920,10 @@ export class Gantt implements IVisual {
             }
 
             this.updateInternal(options);
-        } catch (error) {
-            console.error(error);
-            this.eventService.renderingFailed(options, error as string);
+        } catch (error: unknown) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            console.error(errorMessage);
+            this.eventService.renderingFailed(options, errorMessage);
         }
     }
 
@@ -2608,7 +2609,7 @@ export class Gantt implements IVisual {
         maxWidth: number,
         maxHeight: number = 2
     ): void {
-        selection.each(function (task: GroupedTask) {
+        selection.each(function (this: SVGTextElement, task: GroupedTask) {
             const textElement = d3Select(this);
             const text = task.name;
             const computedStyle = window.getComputedStyle(this);
@@ -2785,7 +2786,7 @@ export class Gantt implements IVisual {
 
         const buttonPlusMinusColor = this.colorHelper.getHighContrastColor("foreground", Gantt.DefaultValues.PlusMinusColor);
         buttonSelection
-            .each(function (task: GroupedTask) {
+            .each(function (this: SVGSVGElement, task: GroupedTask) {
                 const element = d3Select(this) as unknown as d3Selection<SVGElement, any, any, any>;
                 if (!task.tasks[0].children![0].visibility) {
                     drawPlusButton(element, buttonPlusMinusColor);
@@ -3258,7 +3259,7 @@ export class Gantt implements IVisual {
                 .style("stroke-width", taskSettings.border.width.value || highContrastModeTaskRectStroke);
         }
 
-        taskRectMerged.each(function (d: Task) {
+        taskRectMerged.each(function (this: SVGPathElement, d: Task) {
             const node = d3Select(this);
             const width = Number(node.attr("width"));
             if (isNaN(width) || width === 0) {
@@ -3630,13 +3631,13 @@ export class Gantt implements IVisual {
 
             if (taskResourceWidthByTask) {
                 taskResourceMerged
-                    .each(function (task: Task) {
+                    .each(function (this: SVGTextElement, task: Task) {
                         const width: number = hasNotNullableDates && task.start && task.end ? Gantt.taskDurationToWidth(task.start, task.end) : 0;
                         AxisHelper.LabelLayoutStrategy.clip(d3Select(this), width - Gantt.RectRound * 2, textMeasurementService.svgEllipsis);
                     });
             } else if (isGroupedByTaskName) {
                 taskResourceMerged
-                    .each(function (task: Task, outerIndex: number) {
+                    .each(function (this: SVGTextElement, task: Task, outerIndex: number) {
                         const sameRowNextTaskStart: Date | null = Gantt.getSameRowNextTaskStartDate(task, outerIndex, taskResourceMerged);
 
                         if (sameRowNextTaskStart) {
@@ -3655,7 +3656,7 @@ export class Gantt implements IVisual {
                     });
             } else if (!taskResourceFullText) {
                 taskResourceMerged
-                    .each(function () {
+                    .each(function (this: SVGTextElement) {
                         AxisHelper.LabelLayoutStrategy.clip(d3Select(this), defaultWidth, textMeasurementService.svgEllipsis);
                     });
             }

--- a/src/services/settingsState.ts
+++ b/src/services/settingsState.ts
@@ -118,7 +118,7 @@ export class SettingsState {
             return JSON.stringify(oldState) === JSON.stringify(newState);
         } catch (error: unknown) {
             const errorMessage = error instanceof Error ? error.message : String(error);
-            console.warn("Could not compare settings states", errorMessage);
+            console.warn("Could not compare settings states", errorMessage, error);
             return false;
         }
     }

--- a/src/services/settingsState.ts
+++ b/src/services/settingsState.ts
@@ -116,8 +116,9 @@ export class SettingsState {
     private areStatesEqual(oldState: ISettingsState, newState: ISettingsState): boolean {
         try {
             return JSON.stringify(oldState) === JSON.stringify(newState);
-        } catch (e) {
-            console.warn("Could not compare settings states", e);
+        } catch (error: unknown) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            console.warn("Could not compare settings states", errorMessage);
             return false;
         }
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,9 @@
     "strictNullChecks": true,
     "strictFunctionTypes": true,
     "strictBindCallApply": true,
+    "useUnknownInCatchVariables": true,
+    "alwaysStrict": true,
+    "noImplicitThis": true,
     "noImplicitAny": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
- tsconfig.json: turn on useUnknownInCatchVariables, alwaysStrict, noImplicitThis
- Type both catch variables as unknown and normalize them with an
  `error instanceof Error ? error.message : String(error)` runtime check
- Drop the stage-1 `error as string` cast in eventService.renderingFailed()
  inside update(); pass the normalized message instead
- Annotate d3 `.each(function () { ... })` callbacks that rely on `this`
  with explicit element types (SVGTextElement, SVGSVGElement, SVGPathElement)