### PR TITLE
fix: fetch all data segments to prevent silent truncation of large datasets

### DIFF
--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -1915,6 +1915,7 @@ export class Gantt implements IVisual {
             // Without this, PBI only delivers the first ~1000-row segment and never calls update() with the rest.
             if (options.dataViews[0].metadata.segment) {
                 this.host.fetchMoreData(true);
+                return;
             }
 
             const collapsedTasksUpdateId: any = options.dataViews[0].metadata?.objects?.collapsedTasksUpdateId?.value;

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -1912,6 +1912,11 @@ export class Gantt implements IVisual {
                 return;
             }
 
+            // Without this, PBI only delivers the first ~1000-row segment and never calls update() with the rest.
+            if (options.dataViews[0].metadata.segment) {
+                this.host.fetchMoreData(true);
+            }
+
             const collapsedTasksUpdateId: any = options.dataViews[0].metadata?.objects?.collapsedTasksUpdateId?.value;
 
             if (this.collapsedTasksUpdateIDs.includes(collapsedTasksUpdateId)) {


### PR DESCRIPTION
Fixes #557

## Problem

When a categorical dataset is large enough to require segmentation, the visual
silently renders only the first segment (~1000 rows). No error is shown — data
is simply missing with no indication to the user.

**Root cause:** Power BI streams large categorical datasets in ~1000-row segments.
Each intermediate segment arrives via a new `update()` call with
`options.dataViews[0].metadata.segment` set. The visual must call
`this.host.fetchMoreData()` to request the next segment — but `update()` never
does, so only the first segment is ever processed.

This is independent of `dataReductionAlgorithm.count`. Raising the count sets
the total row cap but does not prevent segmentation — PBI still delivers the
data in batches.

## Reproduction

1. Bind a categorical dataset with more than ~1000 rows (e.g. 200+ tasks each
   with several grouped value columns).
2. Observe that only the first ~20–25 tasks render. No warning is shown.

The breakpoint is determined by segment size, not by any visual setting.

## Fix

Add the following inside `update()`, after the null-dataViews guard:

```ts
if (options.dataViews[0].metadata.segment) {
    this.host.fetchMoreData(true);
}